### PR TITLE
Fix scoring bug

### DIFF
--- a/src/main/java/com/intuit/fuzzymatcher/domain/Element.java
+++ b/src/main/java/com/intuit/fuzzymatcher/domain/Element.java
@@ -125,16 +125,17 @@ public class Element<T> implements Matchable {
     }
 
     public double getScore(Integer matchingCount, Element other) {
-        return ((double)matchingCount / (double) getChildCount(other));
+        return ((double)matchingCount / getWeightedChildCount(other));
     }
 
 
     /**
      * This gets the Max number of tokens present between matching Elements.
      * For Elements that do not have a balanced set of tokens, it can push the score down.
+     * @return
      */
     @Override
-    public long getChildCount(Matchable other) {
+    public double getWeightedChildCount(Matchable other) {
         if (other instanceof Element) {
             Element<T> o = (Element<T>) other;
             return Math.max(this.getTokens().size(), o.getTokens().size());
@@ -143,7 +144,7 @@ public class Element<T> implements Matchable {
     }
 
     @Override
-    public long getUnmatchedChildCount(Matchable other) {
+    public double getUnmatchedChildWeight(Matchable other) {
         if (other instanceof Element) {
             Element<T> o = (Element<T>) other;
             long emptyChildren = this.getTokens().stream()
@@ -228,8 +229,9 @@ public class Element<T> implements Matchable {
 
     @Override
     public String toString() {
-        return "{" +
-                "'" + value + '\'' +
+        return "Element{" +
+                "value=" + value +
+                ", classification=" + elementClassification +
                 '}';
     }
 

--- a/src/main/java/com/intuit/fuzzymatcher/domain/ElementClassification.java
+++ b/src/main/java/com/intuit/fuzzymatcher/domain/ElementClassification.java
@@ -1,9 +1,6 @@
 package com.intuit.fuzzymatcher.domain;
 
-import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Stream;
 
 /**
  * Defines how each element is classified using ElementType and variance.
@@ -43,5 +40,10 @@ public class ElementClassification {
     @Override
     public int hashCode() {
         return Objects.hash(elementType, variance);
+    }
+
+    @Override
+    public String toString() {
+        return elementType.name() + ":" + variance;
     }
 }

--- a/src/main/java/com/intuit/fuzzymatcher/domain/Matchable.java
+++ b/src/main/java/com/intuit/fuzzymatcher/domain/Matchable.java
@@ -9,11 +9,11 @@ import java.util.function.BiFunction;
  */
 public interface Matchable {
 
-    public long getChildCount(Matchable other);
+    public double getWeightedChildCount(Matchable other);
 
     public BiFunction<Match, List<Score>, Score> getScoringFunction();
 
     public double getWeight();
 
-    public long getUnmatchedChildCount(Matchable other);
+    public double getUnmatchedChildWeight(Matchable other);
 }

--- a/src/test/java/com/intuit/fuzzymatcher/component/MatchServiceTest.java
+++ b/src/test/java/com/intuit/fuzzymatcher/component/MatchServiceTest.java
@@ -111,7 +111,8 @@ public class MatchServiceTest {
 
     @Test
     public void itShouldApplyMatchByDocIdForAList() throws IOException {
-        Map<String, List<Match<Document>>> result = matchService.applyMatchByDocId(getTestDocuments());
+        List<Document> documents = getTestDocuments();
+        Map<String, List<Match<Document>>> result = matchService.applyMatchByDocId(documents);
         writeOutput(result);
         Assert.assertEquals(6, result.size());
     }

--- a/src/test/java/com/intuit/fuzzymatcher/domain/DocumentTest.java
+++ b/src/test/java/com/intuit/fuzzymatcher/domain/DocumentTest.java
@@ -22,9 +22,9 @@ public class DocumentTest {
                 .addElement(new Element.Builder().setType(EMAIL).setValue("james@email.com").createElement())
                 .createDocument();
 
-        Assert.assertEquals(4, d1.getChildCount(d2));
-        Assert.assertEquals(4, d2.getChildCount(d1));
-        Assert.assertEquals(2, d1.getUnmatchedChildCount(d2));
+        Assert.assertEquals(4, d1.getWeightedChildCount(d2), 0.01);
+        Assert.assertEquals(4, d2.getWeightedChildCount(d1), 0.01);
+        Assert.assertEquals(2, d1.getUnmatchedChildWeight(d2), 0.01);
     }
 
     @Test
@@ -42,8 +42,8 @@ public class DocumentTest {
                 .addElement(new Element.Builder().setType(EMAIL).setValue("").createElement())
                 .createDocument();
 
-        Assert.assertEquals(2, d1.getChildCount(d2));
-        Assert.assertEquals(0, d1.getUnmatchedChildCount(d2));
+        Assert.assertEquals(2, d1.getWeightedChildCount(d2), 0.01);
+        Assert.assertEquals(0, d1.getUnmatchedChildWeight(d2), 0.01);
     }
 
     @Test
@@ -61,8 +61,8 @@ public class DocumentTest {
                 .addElement(new Element.Builder().setType(EMAIL).setValue("").createElement())
                 .createDocument();
 
-        Assert.assertEquals(3, d1.getChildCount(d2));
-        Assert.assertEquals(2, d1.getUnmatchedChildCount(d2));
+        Assert.assertEquals(3, d1.getWeightedChildCount(d2), 0.01);
+        Assert.assertEquals(2, d1.getUnmatchedChildWeight(d2), 0.01);
     }
 
     @Test
@@ -81,8 +81,8 @@ public class DocumentTest {
                 .addElement(new Element.Builder().setType(EMAIL).setValue("").createElement())
                 .createDocument();
 
-        Assert.assertEquals(4, d1.getChildCount(d2));
-        Assert.assertEquals(3, d1.getUnmatchedChildCount(d2));
+        Assert.assertEquals(4, d1.getWeightedChildCount(d2), 0.01);
+        Assert.assertEquals(3, d1.getUnmatchedChildWeight(d2), 0.01);
     }
 
     @Test
@@ -101,7 +101,7 @@ public class DocumentTest {
                 .addElement(new Element.Builder().setType(EMAIL).setValue("").createElement())
                 .createDocument();
 
-        Assert.assertEquals(3, d1.getChildCount(d2));
-        Assert.assertEquals(1, d1.getUnmatchedChildCount(d2));
+        Assert.assertEquals(3, d1.getWeightedChildCount(d2), 0.01);
+        Assert.assertEquals(1, d1.getUnmatchedChildWeight(d2), 0.01);
     }
 }

--- a/src/test/java/com/intuit/fuzzymatcher/function/ScoringFunctionTest.java
+++ b/src/test/java/com/intuit/fuzzymatcher/function/ScoringFunctionTest.java
@@ -9,68 +9,18 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ScoringFunctionTest {
 
     @Test
-    public void itShouldGiveAverageScore_Success(){
-        Document document1 = getMockDocument(4L, 0L);
-        Document document2 = getMockDocument(4L, 0L);
-
-        Match<Document> match = getMockMatch(document1, document2);
-        List<Score> childScores = getMockChildScores(new Match(getMockElement(1.0, 1), null, 0.66),
-                new Match(getMockElement(2.0, 1), null, 1.0));
-
-        Score score = ScoringFunction.getAverageScore().apply(match, childScores);
-        Assert.assertEquals(0.41, score.getResult(), 0.01);
-    }
-
-    @Test
-    public void itShouldGiveAverageScoreWithEmptyFields_Success(){
-        Document document1 = getMockDocument(4L, 2L);
-        Document document2 = getMockDocument(4L, 0L);
-
-        Match<Document> match = getMockMatch(document1, document2);
-        List<Score> childScores = getMockChildScores(new Match(getMockElement(1.0, 1), null, 0.5),
-                new Match(getMockElement(2.0, 1), null, 1.0));
-
-        Score score = ScoringFunction.getAverageScore().apply(match, childScores);
-        Assert.assertEquals(.62, score.getResult(), 0.01);
-    }
-
-    @Test
-    public void itShouldGiveSimpleAverageScore_Success(){
-        Document document1 = getMockDocument(4L, 0L);
-        Document document2 = getMockDocument(4L, 0L);
-
-        Match<Document> match = getMockMatch(document1, document2);
-        List<Score> childScores = getMockChildScores(new Match(getMockElement(1.0, 1), null, 0.66),
-                new Match(getMockElement(2.0, 1), null, 1.0));
-
-        Score score = ScoringFunction.getSimpleAverageScore().apply(match, childScores);
-        Assert.assertEquals(0.41, score.getResult(), 0.01);
-    }
-
-    @Test
-    public void itShouldGetExponentialScoring_Success(){
-        Document document1 = getMockDocument(4L, 2L);
-        Document document2 = getMockDocument(4L, 0L);
-
-        Match<Document> match = getMockMatch(document1, document2);
-        List<Score> childScores = getMockChildScores(new Match(getMockElement(1.0, 1), null, 1.0),
-                new Match(getMockElement(2.0, 1), null, 1.0));
-
-        Score score = ScoringFunction.getExponentialAverageScore().apply(match, childScores);
-        Assert.assertEquals(.79, score.getResult(), 0.01);
-    }
-
-    @Test
     public void itShouldGiveWeightedAverageScore_Success(){
-        Document document1 = getMockDocument(4L, 2L);
-        Document document2 = getMockDocument(4L, 0L);
+        Document document1 = mock(Document.class);
+        Document document2 = mock(Document.class);
+
+        when(document1.getWeightedChildCount(document2)).thenReturn(5.0);
+        when(document1.getUnmatchedChildWeight(document2)).thenReturn(2.0);
 
         Match<Document> match = getMockMatch(document1, document2);
         List<Score> childScores = getMockChildScores(new Match(getMockElement(1.0, 1), null, 1.0),
@@ -79,11 +29,13 @@ public class ScoringFunctionTest {
         Assert.assertEquals(.8, score.getResult(), 0.01);
     }
 
-
     @Test
     public void itShouldGetExponentialWeightedScoring_Success(){
-        Document document1 = getMockDocument(4L, 2L);
-        Document document2 = getMockDocument(4L, 0L);
+        Document document1 = mock(Document.class);
+        Document document2 = mock(Document.class);
+
+        when(document1.getWeightedChildCount(document2)).thenReturn(5.0);
+        when(document1.getUnmatchedChildWeight(document2)).thenReturn(2.0);
 
         Match<Document> match = getMockMatch(document1, document2);
         List<Score> childScores = getMockChildScores(new Match(getMockElement(1.0, 1), null, 1.0),
@@ -91,13 +43,6 @@ public class ScoringFunctionTest {
 
         Score score = ScoringFunction.getExponentialWeightedAverageScore().apply(match, childScores);
         Assert.assertEquals(.86, score.getResult(), 0.01);
-    }
-
-    private Document getMockDocument(long childCount, long emptyCount) {
-        Document doc = mock(Document.class);
-        when(doc.getChildCount(any())).thenReturn(childCount);
-        when(doc.getUnmatchedChildCount(any())).thenReturn(emptyCount);
-        return doc;
     }
 
     private Element getMockElement(double weight, long childCount) {


### PR DESCRIPTION
There are two main issues w/the scoring functions as they exist in the original project

1. There are a variety of functions unaccessible from calling clients, there's no functionality to set custom scoring functions so why define them
2. The default scoring functions are broken. They claim to be "weighted" but only consider weights for matched elements. Any unmatched element is assumed to have weight 1. This can produce inaccurate results in a variety of cases, the most obvious is matching on two elements:

e1: NAME, weight: .01
e2: ADDRESS, weight: .1

If we assume two documents:
d1 w/ ADDRESS = "123 Main st"
d2 w/ ADDRESS = "123 Main st" NAME = "John Doe"
The old `getWeightedAverageScore` would have = (.1 + .5) / (.1 + 2 - 1) = .5454
The new `getWeightedAverageScore` would have = (.1 + .005) / (.11) = .95454

The minimally weighted name is disproportionately pulling down the score